### PR TITLE
Retrieve NHSO Health Info with ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Most of the data could be bought e.g. [dbd](https://medium.com/incubate-co-th/%E
 * [Revenue Department API](https://zenateconnect.github.io/RevenueDepartmentService/) - Obtain more info about a tax ID/national ID.
 * [national-id-meaning](https://github.com/heypoom/national-id-meaning) - Understand info behind national ID numbering.
 * [CheckMD](https://checkmd.tmc.or.th/) - Check if a name is a legal doctor as well as their specialties.
+* [NHSO Health Lookup](https://srmcitizen.nhso.go.th/) - Look up NHSO health information using ID and date of birth.
 * [TH Portal](https://thportal.bora.dopa.go.th/#/) - Centralize individual data, living place, driving license, lands owned, cars owned, military notes, etc.
 * [ThaiD App](https://play.google.com/store/apps/details?id=th.go.dopa.bora.dims.ddopa&hl=en&pli=1) - Government Authentication (Sign in with ThaiD) for Thai as well as a lot of services by Ministry.
 


### PR DESCRIPTION
Added srmcitizen.nhso.go.th which allows users to look up NHSO health information using their ID and date of birth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)