### PR TITLE
docs: add contribution rules to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,3 +181,19 @@ Most of the data could be bought e.g. [dbd](https://medium.com/incubate-co-th/%E
 
 Feel free to update this list by creating a pull request 🥰
 
+**What belongs here**
+
+* **Thai-relevant** — a Thai data source, or a general-purpose tool that meaningfully helps OSINT work on Thailand.
+* **Free to use** — self-hostable, or a public service anyone can reach. Paid and credit-billed APIs, SaaS trials, and anything requiring a vendor account are out.
+* **Established** — the *Well-Maintained OSINT* section is for tools already in real use, not new projects looking for visibility.
+* **One entry per PR**, in the matching section, following the existing format:
+
+  ```markdown
+  * **[Name](https://example.com)**
+    One line on what it does.
+  ```
+
+  Leave the `(3d)` / `(⚠️ 1yr 3mo)` timestamps out — [a monthly workflow](.github/workflows/update-commit-dates.yml) adds and refreshes them.
+
+**Not accepted:** promotion of your own commercial product, and automated or templated listing PRs sent to many repos at once. These get closed without discussion.
+


### PR DESCRIPTION
Adds a short set of rules under `# Contributing`, so listing PRs that don't fit can be closed by pointing at a stated rule instead of arguing case by case.

Prompted by #12 — one of ~2,500 near-identical automated "Add Xquik" PRs opened across GitHub from a single account, pushing a commercial hosted API with no Thai relevance.

**Rules added:** Thai-relevant · free to use · established (for *Well-Maintained OSINT*) · one entry per PR in the existing format · leave the `(3d)` timestamps to the monthly workflow. Plus an explicit "not accepted" line for self-promotion and mass templated listing PRs.

Verified the `update_commit_dates.py` workflow leaves the new section untouched — its regex only matches `github.com` links, so the `example.com` snippet and the relative workflow link are both safe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019kcEe4oYLvedEXEXD4RaKp
