### PR TITLE
Add Company Records to Government/Official Data

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,9 @@ Most of the data could be bought e.g. [dbd](https://medium.com/incubate-co-th/%E
 * **[Department of Business Development](http://datawarehouse.dbd.go.th/)**
   All companies' financial stats include those not in the [SET](https://www.set.or.th/set/mainpage.do?language=en&country=US).
 
+* **[Company Records](https://records.knowyourcustomer.com/)**
+  Free anonymous company search across 149 jurisdictions, including Thailand (DBD-sourced); on purchase, the company report and official filings are retrieved live from the official register (paid, from US$19).
+
 * **[Creden](https://creden.co/creditscore/business/main.html)**
   DBD (Department of Business Development) that could be queried using the person's name.
 


### PR DESCRIPTION
Disclosure: this is an affiliated submission; I work with Know Your Customer Limited, which operates this service.

Adds one entry to Government/Official Data, next to the Department of Business Development listing: Company Records (https://records.knowyourcustomer.com/), operated by Know Your Customer Limited, provides live company-registry information for 149 jurisdictions, each with its own coverage page. Company search is free and anonymous with no login; on purchase, the company report and the underlying official filings are retrieved live from the official register at the moment of purchase, not from a cached or aggregated database. A single purchase starts at US$19, with no subscription, and an account is needed only at the point of purchase.

Happy to adjust wording or placement, and no problem at all if this isn't a fit for the list.
